### PR TITLE
C Reed suggested edits etc

### DIFF
--- a/charter/OGC-API-Maps-SWG-Charter.adoc
+++ b/charter/OGC-API-Maps-SWG-Charter.adoc
@@ -58,44 +58,42 @@ The formal proposed name of the new multi-part standard is "{swgname}". The shor
 
 === Business Value Proposition
 
-In October 2019, the Programmable Web https://www.programmableweb.com/news/which-are-developers-favorite-apis/research/2019/10/24[reported] that a web mapping product was amongst the top-two tracked APIs on the Programmable Web API directory. The presence of a web mapping product amongst the top-two tracked APIs on Programmable Web is evidence of the wide interest across both the geospatial community and the general public. However, further evidence of the popularity and adoption of web mapping can be seen from the uptake of the Web Map Service (WMS) standard which is listed - as of May 2020 - as having the most number of implementations on the OGC https://www.ogc.org/resource/products/stats[Implementation Statistics] webpage.
+In October 2019, the Programmable Web https://www.programmableweb.com/news/which-are-developers-favorite-apis/research/2019/10/24[reported] that a web mapping product was amongst the top-two tracked APIs on the Programmable Web API directory. The presence of a web mapping product among the top-two tracked APIs on Programmable Web is evidence of the wide interest across both the geospatial community and the general public. Further evidence of the popularity and adoption of web mapping can be seen from the uptake of the Web Map Service (WMS) standard which,as of May 2020, has the most implementations of any of the OGC standards. See: https://www.ogc.org/resource/products/stats[Implementation Statistics].
 
 === Scope of Work
 
-OpenAPI frameworks have helped make describing and sharing API definitions more suitable for interoperability standardization. The concept of a {shortname} was demonstrated in various OGC Innovation Program initiatives.
+The use of OpenAPI and Swagger have provided a framework for describing and sharing OGC API definitions more suitable for interoperability standardization. The concept of a {shortname} was demonstrated in various OGC Innovation Program initiatives.
 
-The {swgname} SWG will build on those preliminary efforts to more fully develop and document a {shortname} candidate standard that will provide a modernized, common, and consistent interface to services that aligns with the current architecture of the Web and the
-Spatial Data on the Web Best Practices (https://www.w3.org/TR/sdw-bp/).
+The {swgname} SWG will build on those efforts to more fully develop and document a {shortname} candidate standard that will provide a web based, common, and consistent interface to services that aligns with the current architecture of the Web and the Spatial Data on the Web Best Practices (https://www.w3.org/TR/sdw-bp/).
 
-The {swgname} SWG will develop a {shortname} candidate standard which is informed by emerging OGC API best practices and prior API standards examples (e.g., OGC API - Features) to define core API functions of GET, PUT, PATCH, POST, DELETE applied to {resources} as resources. The {shortname} will also document metadata requirements for {resources} to enhance discovery and exchange of {resources}.
+The {swgname} SWG will develop a {shortname} candidate standard which is consistent with the emerging OGC API best practices and existing OGC API standards examples, such as the OGC API - Features, to define core API functions of GET, PUT, PATCH, POST, DELETE applied to {resources} as resources. The {shortname} will also document metadata requirements for {resources} to enhance discovery and exchange of {resources}.
 
-* Architecture: The {swgname} standard will specify an implementation specification aligned with prior work in OGC for {resources} and Web APIs. The proposed standard will define API building blocks for {resources} in Web API. {swgname} will be consistent with HTTP and HTTPS.
+* Architecture: The {swgname} standard will specify an implementation standard aligned with prior work in OGC for {resources} and Web APIs. The proposed standard will define API building blocks for {resources}. {swgname} will be consistent with HTTP and HTTPS.
 
 *	Encodings: The first version of the {shortname} will support JSON and HTML as encodings for descriptions of {resource} resources in the API. No encoding will be mandatory and other encodings may be used as well. The HTTP focus is designed to support the use of multiple formats and defines rules about how servers can return the encoding that the client can best handle (“content negotiation”).
 
-* Information model: The {shortname} standard will conform to OpenAPI models and OGC API best practices. The conceptual models will consider recommendations from recent and current OGC Innovation Program initiatives such as Testbeds, Pilots, Sprint and others.
+* Information model: The {shortname} standard will utilize standard modelling languages such as UML to decribe infromation model(s) and as well follow OGC API best practices. The development of any conceptual and logical models underpinning {shortname} will consider recommendations from recent and current OGC Innovation Program initiatives such as Testbeds, Pilots, Sprint and others.
 
-* Modularization: {swgname} - Part 1: Core will define a basic set of capabilities organized in multiple conformance classes building on each other. The minimal conformance class will specify a simple interface to access metadata from {resources} that is sufficient for interfaces to exchange and perform basic web functions with the {resources}. Additional conformance classes will define additional capabilities based on the requirements and requirements classes defined in the core to meet the needs of use cases that require such capabilities.
+* Modularization: {swgname} - Part 1: Core will define a basic set of capabilities organized in multiple conformance classes building on each other. The minimal conformance class will specify a simple interface to access metadata from {resources} that is sufficient for interfaces to exchange and perform basic web functions with the {resources}. Additional conformance classes will define additional extensions based on the requirements and requirements classes defined in the core. These extensions will meet the needs of use cases that require such capabilities.
 
-* Reuse: The use of unique {shortname} resources or components will be minimized and, where available, existing industry-standards or patterns that are commonly used by developers will be used instead. The most important example for this is the use of an OpenAPI definition instead of OGC-specific "Capabilities" documents and the use of OGC API - Common components to the maximum extent practicable.
+* Reuse: The use of unique {shortname} resources or components will be minimized and, where available, will instead use existing industry-standards or patterns that are commonly used by developers . The most important example for this is the use of an OpenAPI description instead of OGC-specific "Capabilities" documents and to use the OGC API - Common components to the maximum extent practicable.
 
-Extensions may be proposed and addressed in revisions to this charter. The primary goal of the {shortname} SWG is to develop the core of "{swgname}" as quickly as possible and work on extensions after that, driven by community interest. An important aspect is to ensure that implementing the standard will lead to efficient implementations, happy developers of both server and client components, and satisfied users of such components.
+Extensions may be proposed and addressed in revisions to this charter. The primary goal of the {shortname} SWG is to develop the core of "{swgname}" as quickly as possible and work on extensions after that. Extensions will be driven by community interest. An important aspect is to ensure that implementing the standard will lead to efficient implementations, happy developers of both server and client components, and satisfied users of such components.
 
+Before finalizing parts of the future versions of the "{swgname}", completion of the following goals should be verified:
 
-Before finalizing parts of the future versions of the "{swgname}", completion of goals should be verified:
-
-*	Working implementations of all capabilities must be available and tested; and
+*	Working implementations of all capabilities must be available and tested.
 *	Implementation feedback must be taken into account.
 
-A consequence of this verification is that the period between the availability of what is considered a mature draft and the finalization of the candidate standard may be longer than in the past, depending on the availability of evidence about the suitability of the candidate standard based on implementations. Developers should be encouraged as early as possible to implement the draft API specification and provide feedback. An aspect of this is public access to drafts from the beginning. To this end, the SWG intends to use a public GitHub repository in the development of this standard as this is the environment many developers are familiar with and use on a daily basis.
+A consequence of this verification process is that the period between the availability of what is considered a mature draft and the finalization of the candidate standard may be longer than in the past. The length of time depends on the availability of evidence about the suitability of the candidate standard based on implementations. Developers will be encouraged as early as possible to implement the draft API specification and provide feedback. An aspect of this is public access to drafts from the beginning. To this end, the SWG intends to use a public GitHub repository in the development of this standard. The OGC believes GitHub is the environment many developers are familiar with and use on a daily basis.
 
 ==== Statement of relationship of planned work to the current OGC standards baseline
 
-This proposed standard is intended to be a major component of the OGC API framework. The proposed standard will take advantage of Web API patterns identified in OGC API standards (e.g., OGC API – Features) and other ongoing API efforts (e.g. OGC API - Common development in OWS Common SWG) to better align with current and emerging IT practices.  The {shortname} provides a means for sharing {resources} developed under OGC and other {resource} encodings.
+This proposed standard is intended to be a major component of the OGC API framework. The proposed standard will take advantage of Web API patterns identified in existing OGC API standards, such as OGC API – Features, and other ongoing API efforts (e.g. OGC API - Common development in OWS Common SWG). This approach will enable better align with current and emerging IT practices.  The {shortname} provides a means for sharing {resources} developed under OGC and other {resource} encodings.
 
 ==== What is Out of Scope?
 
-Standards are important for interoperability. At the same time, it is important that standards only state requirements that are important for a significantly large group of users. Proposals for new parts of {swgname} or change requests to existing parts must identify the user group that will benefit from the proposal and for each proposed conformance class; otherwise the proposal will be considered out-of-scope.
+Standards are important for interoperability. At the same time, it is important that standards only state requirements that are important for a significantly large group of users. Proposals for new parts of {swgname} or change requests to existing parts to the draft standard must identify the user group that will benefit from the proposal and for each proposed conformance class. Otherwise the proposal will be considered out-of-scope.
 
 {swgname} is envisioned to be a modular, multi-part standard. Extensions and profiles not identified as in scope in the previous section will require a revision to the SWG charter prior to commencement of work. If a community has a need to develop a profile, the profile should be specified and governed by that community.
 
@@ -105,10 +103,10 @@ The basic resource described in {swgname} are {resources}. The {shortname} descr
 
 The starting point for the work will be the draft document that is currently on the proposed SWG's repository ({githubrepo}). This charter recognises the prior work done by the {base_swg}. Upon approval of this Charter, responsibility for {swgname} and WMS standards shall be transferred to the proposed {swgname} SWG. The OGC API - Maps SWG will meet with the OGC API - Tiles SWG on a regular basis.
 
-The work shall also be informed by the following specifications and by recommendations found in:
+The work shall also be based on the following specifications and by recommendations found in:
 
-*	OGC/W3C Spatial Data Working Group on the Web Best Practices (https://www.w3.org/TR/sdw-bp/);
-*	OGC Geospatial API White Paper [OGC 16-019r4];
+*	OGC/W3C Spatial Data Working Group on the Web Best Practices (https://www.w3.org/TR/sdw-bp/).
+*	OGC Geospatial API White Paper [OGC 16-019r4].
 *	OGC API - Features - Part 1: Core standard, [OGC 17-069r3].
 
 Each of these documents recommends an emphasis on resource-oriented APIs in future OGC standards development including use of tools such as OpenAPI.
@@ -129,8 +127,8 @@ The SWG can be inactivated once the final multipart standard has been developed 
 
 The following deliverables will result from the work of this SWG:
 
-*	A final version of the "{swgname} - Part 1: Core" document for submission to the TC;
-*	Identification of at least three prototype implementations of the core based on the standard — although more would be preferred; and
+*	A final version of the "{swgname} - Part 1: Core" document for submission to the TC.
+*	Identification of at least three prototype implementations of the core based on the standard — although more would be preferred. 
 *	Zero or more additional parts as time and community interest permits.
 
 Part 1 will cover basic capabilities to GET, PUT, PATCH, POST, and DELETE {resources} and define {resource} metadata. Capabilities for richer {resource} interfaces or extension for unique geospatial resource considerations will be specified in additional parts.


### PR DESCRIPTION
Hi. This branch contains a number of suggested edits. I noticed in a number of the recent draft charters for the API work the use of two terms: OpenAPI Framework and OpenAPI models. This wording seemed strange to me so I did a bit of research. The OGC has been a bit "loosey goosey" in throwing around OpenAPI based wording. 

The OpenAPI Specification, originally known as the Swagger Specification, is a specification for machine-readable interface files for describing, producing, consuming, and visualizing RESTful web services. (Wikipedia). OpenAPI is not a framework. Swagger is a framework of tools ans other capabilities that includes the OpenAPI specification. Yes, there is also a large number of OpenAPI tools but OpenAPI itself is a specification and not a framework.

OpenAPI is also not an information modelling language. Sure, you can graph your API or a data structure. And of course applications implemented based on OpenAPI interface files can automatically generate documentation of methods, parameters and models. But these models are related to the API interface(s) and not any underlying information models as we think of them. An information model in software engineering is a representation of concepts and the relationships, constraints, rules, and operations to specify data semantics for a chosen domain of discourse. Typically it specifies relations between kinds of things, but may also include relations with individual things.